### PR TITLE
GPFILTERPANE-81 Fix multiple associations to same domain class property

### DIFF
--- a/grails-app/domain/org/grails/plugin/filterpane/nested/Function.groovy
+++ b/grails-app/domain/org/grails/plugin/filterpane/nested/Function.groovy
@@ -2,8 +2,7 @@ package org.grails.plugin.filterpane.nested
 
 import groovy.transform.ToString
 
-// Temporary fix due to groovy version
-@ToString(includes='name')
+@ToString(includes=['name'])
 class Function {
 
     String name = 'function'


### PR DESCRIPTION
Hi,

I've fixed the http://jira.grails.org/browse/GPFILTERPANE-81 based on the provided patch.
I had to make some arrangement since the FilterPaneFieldNamePrefix was the same for all associations related to a specific domain class property. I'm now using a dynamic prefix method in order to store different prefix according to the association used.
