### PR TITLE
Fixes GPFILTERPANE-113

### DIFF
--- a/grails-app/taglib/org/grails/plugin/filterpane/FilterPaneTagLib.groovy
+++ b/grails-app/taglib/org/grails/plugin/filterpane/FilterPaneTagLib.groovy
@@ -175,7 +175,7 @@ class FilterPaneTagLib {
             def domainBean = FilterPaneUtils.resolveDomainClass(grailsApplication, attrs.domainBean)
 
             def getProp = { key, filterOp ->
-                if(key.startsWith('filter.op') && filterOp != null && filterOp != '') {
+                if(key.startsWith('filter.op.') && filterOp != null && filterOp != '') {
                     return key[10..-1]
                 }
                 false


### PR DESCRIPTION
Fixes problem that causes the currentCriteria tag to crash for any property beginning with "op"

http://jira.grails.org/browse/GPFILTERPANE-113
