### PR TITLE
Fix for filtering by Class attribute

### DIFF
--- a/grails-app/services/org/grails/plugin/filterpane/FilterPaneService.groovy
+++ b/grails-app/services/org/grails/plugin/filterpane/FilterPaneService.groovy
@@ -140,8 +140,15 @@ class FilterPaneService {
                             order(params.sort, params.order ?: 'asc')
                         }
                     } else if(defaultSort != null) {
-                        log.debug('No sort specified and default is specified on domain.  Using it.')
-                        order(defaultSort, params.order ?: 'asc')
+                        log.debug('No sort specified and default is specified on domain. Using it.')
+                        // Grails >2.3 uses SortConfig for default sort
+                        if (defaultSort.respondsTo("getName") && defaultSort.respondsTo("getDirection")) {
+                            order(defaultSort.name, defaultSort.direction ?: 'asc')
+                        }
+                        else {
+                            // backward support for older grails
+                            order(defaultSort, params.order ?: 'asc')
+                        }
                     } else {
                         log.debug('No sort parameter or default sort specified.')
                     }


### PR DESCRIPTION
The super classes has a "class" property which can be queried in criteria using the full class name (String). Custom Class properties needs to be passed as Class types.

Documentation also doesn't specify that the supper class "class" property could be filtered only if table-per-hierarchy hibernate mapping is used... Could you include that? :-)
