### PR TITLE
Update FilterPaneService.groovy

### DIFF
--- a/grails-app/services/org/grails/plugin/filterpane/FilterPaneService.groovy
+++ b/grails-app/services/org/grails/plugin/filterpane/FilterPaneService.groovy
@@ -1,7 +1,8 @@
 package org.grails.plugin.filterpane
 
 import org.codehaus.groovy.grails.commons.GrailsApplication
-import org.codehaus.groovy.grails.compiler.GrailsClassLoader
+//import org.codehaus.groovy.grails.compiler.GrailsClassLoader
+import org.codehaus.groovy.grails.compiler.injection.GrailsAwareClassLoader;
 
 class FilterPaneService {
 
@@ -132,7 +133,7 @@ class FilterPaneService {
                     def defaultSort
                     try {
                         def gdb
-                        Class clz = new GrailsClassLoader().loadClass('org.codehaus.groovy.grails.orm.hibernate.cfg.GrailsDomainBinder')
+                        Class clz = new GrailsAwareClassLoader().loadClass('org.codehaus.groovy.grails.orm.hibernate.cfg.GrailsDomainBinder')
                         if (clz) {
                             gdb = clz.newInstance()
                             if (gdb?.class?.simpleName == 'GrailsDomainBinder') {


### PR DESCRIPTION
Filter pane not working with Grails 2.4.2
org.codehaus.groovy.grails.compiler.GrailsClassLoader is deprecated we have to use 
org.codehaus.groovy.grails.compiler.injection.GrailsAwareClassLoader
