### PR TITLE
Update BuildConfig.groovy

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -22,7 +22,7 @@ grails.project.dependency.resolution = {
     }
 
     plugins {
-        compile(":joda-time:1.4")
+        compile(":joda-time:1.5")
 
         build(':release:3.0.1',
               ':rest-client-builder:2.0.1'){


### PR DESCRIPTION
joda-time:1.4 is using grailsConfigurationHolder which is deprecated, as of which filterpane 2.4.2 is not 
working with Grails 2.4.2(grailsConfigurationHolder removed in this version)
