### PR TITLE
Fix date-time fields in Grails 2

### DIFF
--- a/grails-app/taglib/org/grails/plugin/filterpane/FilterPaneTagLib.groovy
+++ b/grails-app/taglib/org/grails/plugin/filterpane/FilterPaneTagLib.groovy
@@ -4,6 +4,11 @@ import static org.codehaus.groovy.grails.io.support.GrailsResourceUtils.appendPi
 
 import org.codehaus.groovy.grails.plugins.GrailsPluginManager
 import org.codehaus.groovy.grails.web.pages.discovery.GrailsConventionGroovyPageLocator
+import org.joda.time.DateTime
+import org.joda.time.Instant
+import org.joda.time.LocalDate
+import org.joda.time.LocalDateTime
+import org.joda.time.LocalTime
 import org.joda.time.base.AbstractInstant
 import org.joda.time.base.AbstractPartial
 import org.springframework.web.servlet.support.RequestContextUtils
@@ -471,6 +476,21 @@ class FilterPaneTagLib {
         Map template = getTemplatePath('dateControl')
 
         out << g.render(template: template.path, plugin: template.plugin, model: [ctrlAttrs: model])
+    }
+
+    def datePicker = { attrs, body ->
+        def ctrlAttrs = attrs.ctrlAttrs
+        def type = ctrlAttrs.domainProperty.type
+
+        if (Date.isAssignableFrom(type)) {
+            out << g.datePicker(ctrlAttrs)
+        } else if (DateTime.isAssignableFrom(type) || Instant.isAssignableFrom(type) || LocalDateTime.isAssignableFrom(type)) {
+            out << joda.dateTimePicker(ctrlAttrs) 
+        } else if (LocalTime.isAssignableFrom(type)) {
+            out << joda.timePicker(ctrlAttrs) 
+        } else if (LocalDate.isAssignableFrom(type)) {
+            out << joda.datePicker(ctrlAttrs) 
+        }
     }
 
     def bool = { attrs, body ->

--- a/grails-app/views/_filterpane/_dateControl.gsp
+++ b/grails-app/views/_filterpane/_dateControl.gsp
@@ -1,24 +1,5 @@
-<%@ page import="org.joda.time.DateTime" %>
-<%@ page import="org.joda.time.Instant" %>
-<%@ page import="org.joda.time.LocalTime" %>
-<%@ page import="org.joda.time.LocalDate" %>
-<%@ page import="org.joda.time.LocalDateTime" %>
-
 <span id="${ctrlAttrs.id}-container" style="${ctrlAttrs.style}">
-  <g:if test="${Date.isAssignableFrom(ctrlAttrs.domainProperty.type)}">
-    <%=g.datePicker(ctrlAttrs)%>
-  </g:if>
-  <g:elseif test="${DateTime.isAssignableFrom(ctrlAttrs.domainProperty.type) ||
-          Instant.isAssignableFrom(ctrlAttrs.domainProperty.type) ||
-          LocalDateTime.isAssignableFrom(ctrlAttrs.domainProperty.type)}">
-    <%=joda.dateTimePicker(ctrlAttrs)%>
-  </g:elseif>
-  <g:elseif test="${LocalTime.isAssignableFrom(ctrlAttrs.domainProperty.type)}">
-    <%=joda.timePicker(ctrlAttrs)%>
-  </g:elseif>
-  <g:elseif test="${LocalDate.isAssignableFrom(ctrlAttrs.domainProperty.type)}">
-    <%=joda.datePicker(ctrlAttrs)%>
-  </g:elseif>
+  <filterpane:datePicker ctrlAttrs="${ctrlAttrs}" />
 
   <g:if test="${ctrlAttrs.name?.endsWith('To')}">
     <input type="hidden"


### PR DESCRIPTION
Use a custom tag instead of scriptlets to insert a date-time picker in a filter pane. Complies with the new Grails 2 GSP codec defaults (i.e. scriptlets are HTML-encoded by default)
