### PR TITLE
Solution for https://jira.grails.org/browse/GPFILTERPANE-130

### DIFF
--- a/grails-app/services/org/grails/plugin/filterpane/FilterPaneService.groovy
+++ b/grails-app/services/org/grails/plugin/filterpane/FilterPaneService.groovy
@@ -42,7 +42,7 @@ class FilterPaneService {
                     def nextFilterParams = rawValue
                     def nextFilterOpParams = filterOp
 
-                    if (!areAllValuesEmptyRecursively(nextFilterParams)) {
+                    if (!areAllValuesEmptyRecursively(nextFilterParams) && !areAllValuesEmptyRecursively(nextFilterOpParams)) {
                         criteria."${propName}" {
                             // Are any of the values non-empty?
                             log.debug("== Adding association ${propName}")


### PR DESCRIPTION
I think this is a safe change since all it does is prevent a criteria association from being created when there are only no-op restrictions included.