### PR TITLE
Solution for https://jira.grails.org/browse/GPFILTERPANE-131

### DIFF
--- a/grails-app/taglib/org/grails/plugin/filterpane/FilterPaneTagLib.groovy
+++ b/grails-app/taglib/org/grails/plugin/filterpane/FilterPaneTagLib.groovy
@@ -269,13 +269,13 @@ class FilterPaneTagLib {
                         def lcFilterOp = filterOp.toString().toLowerCase()
                         switch (lcFilterOp) {
 
-                            case FilterPaneOperationType.IsNull.operation:
-                            case FilterPaneOperationType.IsNotNull.operation:
+                            case FilterPaneOperationType.IsNull.operation.toLowerCase():
+                            case FilterPaneOperationType.IsNotNull.operation.toLowerCase():
                                 filterValue = ''
                                 break
-                            case FilterPaneOperationType.Between.operation:
+                            case FilterPaneOperationType.Between.operation.toLowerCase():
                                 filterValueTo = filterParams["filter.${prop}To"]
-                                if (filterValueTo == 'struct') {
+                                if (filterValueTo == 'date.struct' || filterValueTo == 'struct') {
                                     filterValueTo = FilterPaneUtils.parseDateFromDatePickerParams("filter.${prop}To", params)
                                     if (filterValueTo) {
                                         def df = renderModel.dateFormat


### PR DESCRIPTION
See the JIRA description for details.

I've lower-cased the case values so that they will match against the lower-cased filter operation.

I've also specified that if the filterValue is a date field ('date.struct' as a value), it will attempt to parse it. Previously, the check was only for 'struct', and I've left this in in case there was some behaviour being relied upon that used that value (though given that the case statements were not evaluating this would be surprising).