### PR TITLE
change joda-time dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ dependencies {
 	testCompile "org.grails:grails-plugin-testing"
 
 	console "org.grails:grails-console"
-	compile "org.grails.plugins:joda-time:2.0.0-SNAPSHOT"
+	compile "org.grails.plugins:joda-time:2.0.0"
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
the 2.0.0-SNAPSHOT does not exist anymore and the plugin fails to resolve it, causing an error on startup.