### PR TITLE
Update FilterPaneService.groovy

### DIFF
--- a/grails-app/services/org/grails/plugin/filterpane/FilterPaneService.groovy
+++ b/grails-app/services/org/grails/plugin/filterpane/FilterPaneService.groovy
@@ -169,7 +169,9 @@ class FilterPaneService {
                             order(defaultSort, params.order ?: 'asc')
                         } else {
                             defaultSort.namesAndDirections?.each { name, direction ->
-                                order(name, direction ?: 'asc')
+                                if (name.indexOf('.') < 0) { // if not an association..
+                                    order(name, direction ?: 'asc')
+                                }
                             }
                         }
                     } else {


### PR DESCRIPTION
Fix org.hibernate.QueryException "could not resolve property: module.product.ordinal of: foo.bar.MyDomain" with sort mapping defined as: 
static mapping = {
    ...
    sort([("module.product.ordinal"): "asc", ("tenant.name"): "asc", id: "asc"])
    ...
}