### PR TITLE
Grails 2 fix for sort (order by)

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,3 +1,3 @@
 #Grails Metadata file
 #Tue Aug 12 09:43:23 PDT 2014
-app.grails.version=2.4.3
+app.grails.version=2.5.4

--- a/grails-app/domain/org/grails/plugin/filterpane/nested/Overlord.groovy
+++ b/grails-app/domain/org/grails/plugin/filterpane/nested/Overlord.groovy
@@ -1,0 +1,6 @@
+package org.grails.plugin.filterpane.nested
+
+class Overlord {
+
+	String name = 'lord'
+}

--- a/grails-app/domain/org/grails/plugin/filterpane/nested/Robot.groovy
+++ b/grails-app/domain/org/grails/plugin/filterpane/nested/Robot.groovy
@@ -3,10 +3,17 @@ package org.grails.plugin.filterpane.nested
 class Robot {
 
     String name = 'Bob'
+	Overlord overlord;
 
     static hasMany = [parts: Part]
 
     static constraints = {
         parts nullable:  true
+		overlord nullable: true
     }
+	
+	@Override
+	public String toString() {
+		return "id: ${id}, name: ${name}"
+	}
 }

--- a/grails-app/services/org/grails/plugin/filterpane/FilterPaneService.groovy
+++ b/grails-app/services/org/grails/plugin/filterpane/FilterPaneService.groovy
@@ -157,11 +157,6 @@ class FilterPaneService {
                         log.info ex
                         log.info("No mapping property found on filterClass ${filterClass}")
                     }
-                    if (params.sort) {
-                        if (params.sort.indexOf('.') < 0) { // if not an association..
-                            order(params.sort, params.order ?: 'asc')
-                        }
-                    } else if (defaultSort != null) {
                         log.debug('No sort specified and default is specified on domain. Using it.')
                         // Grails >2.3 uses SortConfig for default sort
                         if (defaultSort instanceof String) {

--- a/test/integration/org/grails/plugin/filterpane/nested/RobotControllerSpec.groovy
+++ b/test/integration/org/grails/plugin/filterpane/nested/RobotControllerSpec.groovy
@@ -77,4 +77,65 @@ class RobotControllerSpec extends Specification {
         model.robotCount == 4
         model.robotList.find { it.name == 'wally' }
     }
+	
+	def "test recursive with sorting on one-to-many"() {
+		given:
+		RobotController robotController = new RobotController()
+		
+		Overlord lord1 = Overlord.findOrSaveWhere(name: 'lord a')
+		Overlord lord2 = Overlord.findOrSaveWhere(name: 'lord b')
+		Overlord lord3 = Overlord.findOrSaveWhere(name: 'lord c')
+		
+		Robot.findOrSaveWhere(name: 'EVE 1', overlord: lord3)
+				.addToParts(Part.findOrSaveWhere(name: 'da')
+				.addToFunctions(Function.findOrSaveWhere(name: 'f1'))
+				.addToFunctions(Function.findOrSaveWhere(name: 'f2')))
+		Robot.findOrSaveWhere(name: 'EVE 2', overlord: lord1)
+				.addToParts(Part.findOrSaveWhere(name: 'ba')
+				.addToFunctions(Function.findOrSaveWhere(name: 'f1'))
+				.addToFunctions(Function.findOrSaveWhere(name: 'f2')))
+		Robot.findOrSaveWhere(name: 'EVE 3', overlord: lord2)
+				.addToParts(Part.findOrSaveWhere(name: 'aa')
+				.addToFunctions(Function.findOrSaveWhere(name: 'f1'))
+				.addToFunctions(Function.findOrSaveWhere(name: 'f2')))
+		Robot.findOrSaveWhere(name: 'EVE 4', overlord: lord2)
+				.addToParts(Part.findOrSaveWhere(name: 'ca')
+				.addToFunctions(Function.findOrSaveWhere(name: 'f1'))
+				.addToFunctions(Function.findOrSaveWhere(name: 'f2')))
+		Robot.findOrSaveWhere(name: 'HK-47', overlord: lord1)
+				.addToParts(Part.findOrSaveWhere(name: 'aa')
+				.addToFunctions(Function.findOrSaveWhere(name: 'f1'))
+				.addToFunctions(Function.findOrSaveWhere(name: 'f2')))
+		
+
+		when:
+		robotController.params.filter = ['name': "EVE", op: ['name': 'ILike', 'parts': ['functions': ['name': 'ILike']]]]
+		robotController.params.sort = 'overlord.name'
+		robotController.params.order = 'desc'
+		robotController.params.listDistinct = true
+		robotController.params.uniqueCountColumn = 'id'
+
+		robotController.filter()
+		def model = robotController.modelAndView.model
+
+		then:
+		println model.robotList
+		model.robotList.size() == 4
+		model.robotCount == 4
+		model.robotList[0].name.startsWith('EVE')
+		
+		/*
+		 * the sort & order (desc) should output the 4 EVE Robots by their overlord's name, so
+		 * EVE 1
+		 * EVE 3 & 4 (same overlord)
+		 * EVE 2
+		 */
+		
+		model.robotList[0].name == 'EVE 1'
+		model.robotList[3].name == 'EVE 2'
+		model.robotList[0].overlord.name == 'lord c'
+		model.robotList[1].overlord.name == 'lord b'
+		model.robotList[2].overlord.name == 'lord b'
+		model.robotList[3].overlord.name == 'lord a'
+	}
 }


### PR DESCRIPTION
Fixes sorting on association, when the filter was not an association!

ex. domainClass.name = “x” and sort =
domainClass.oneToManyAssociation.name

I have added a test for this, in RobotControllerSpec.

Also upped grails version to 2.5.4.