### PR TITLE
Release 3.0.7 cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,6 @@ dependencyManagement {
 }
 
 dependencies {
-	compile "org.grails:grails-core"
-
 	provided "org.grails:grails-plugin-services"
 	provided "org.grails:grails-plugin-domain-class"
 	provided 'org.springframework.boot:spring-boot-starter-logging'

--- a/grails-app/services/org/grails/plugins/filterpane/FilterPaneService.groovy
+++ b/grails-app/services/org/grails/plugins/filterpane/FilterPaneService.groovy
@@ -214,7 +214,7 @@ class FilterPaneService {
                            (FilterPaneOperationType.IBeginsWith.operation): 'ilike', (FilterPaneOperationType.BeginsWith.operation): 'like',
                            (FilterPaneOperationType.IEndsWith.operation): 'ilike', (FilterPaneOperationType.EndsWith.operation): 'like']
 
-        println "Operation $op maps ${criteriaMap.get(op)}"
+        log.debug "Operation $op maps ${criteriaMap.get(op)}"
 
         //needs null check since '' or 0 are valid filter
         if (op && value != null) {


### PR DESCRIPTION
Grails Core as dependency (maybe in combination with `apply plugin: "spring-boot"`? I am not really sure what is happening) causes plugin's application.yml to override application config.

@ctoestreich please merge and release - we cannot use 3.0.7 since it is overriding our config